### PR TITLE
Add concept of a connection settings type

### DIFF
--- a/skeleton_etl/connections/abstract.py
+++ b/skeleton_etl/connections/abstract.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractstaticmethod
+from abc import ABC, abstractstaticmethod, abstractclassmethod
 from typing import Any, List
 from ..models.message import Message
 
@@ -8,8 +8,18 @@ from ..selection_policies.abstract import SelectionPolicy
 
 class Connection(ABC):
 
-    @abstractstaticmethod
-    def connect(gateway: Gateway) -> Any:
+    connection_settings_type: Any
+
+    @classmethod
+    def _check_connection_settings_type(cls, settings):
+        if not isinstance(settings, cls.connection_settings_type):
+            raise TypeError(
+                f"Connection settings of type {type(settings).__qualname__} "
+                f"not {cls.connection_settings_type.__qualname__}"
+            )
+
+    @abstractclassmethod
+    def connect(cls, gateway: Gateway) -> Any:
         """
         Create and return a connection object that is connected to the source
         described by `gateway`.
@@ -17,22 +27,22 @@ class Connection(ABC):
         methods requirements for `conn`
         """
         return None
-    
+
     @abstractstaticmethod
     def receive_inputs(conn: Any, path: str, message_selector: SelectionPolicy) -> List[Message]:
         """
         Using the connection `conn` returns from `SelectionPolicy.connect()`,
         and the `path` to search within that connection, collect new messages.
-        
+
         `message_selector` is to be used to decide which messages to receive.
-        
+
         Requiring message_selector to be correctly used in this custom code is not ideal. It would be
         far nicer if the possible messages were all retrieved, then the selection policy were
         *automatically* applied.
         However, this approach is currently used because the point at which sufficient information
         about the incoming message is available may vary depending on the connection. e.g. local
         filesystem compared to SFTP, or Google Drive.
-        
+
         TODO reconsider requirement to use SelectionPolicy. Is it widely-applicable enough and in the right place?
         """
         return []

--- a/skeleton_etl/connections/filesystem.py
+++ b/skeleton_etl/connections/filesystem.py
@@ -1,18 +1,36 @@
 import pathlib
 import hashlib
+from dataclasses import dataclass, field
+from typing import Union
 
 from ..models.message import Message
+from .abstract import Connection
 
 import logging
 
 _logger = logging.getLogger(__name__)
 
 
-class LocalFilesystemConnection:
-    @staticmethod
-    def connect(_gateway):
+@dataclass
+class LocalFilesystemConnectionSettings:
+
+    root_path: Union[str, pathlib.Path, None] = field(default=None)
+
+
+class LocalFilesystemConnection(Connection):
+
+    connection_settings_type = LocalFilesystemConnectionSettings
+
+    @classmethod
+    def connect(cls, gateway):
         """Connect to local filesystem"""
-        return pathlib.Path(pathlib.Path().absolute().root)
+        settings = gateway.connection_settings
+        cls._check_connection_settings_type(settings)
+
+        if settings.root_path:
+            return pathlib.Path(settings.root_path).absolute()
+        else:
+            return pathlib.Path(pathlib.Path().absolute().root)
 
     @classmethod
     def receive_inputs(cls, conn, path, message_selector):

--- a/skeleton_etl/models/gateway.py
+++ b/skeleton_etl/models/gateway.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, List, Union
+from typing import Any, List, Dict
 
 from .transfer import Transfer
 from ..stores.abstract import AbstractStore
@@ -14,7 +14,7 @@ class Gateway:
     """
 
     path: str
-    address: Union[str, None]
+    connection_settings: Dict[str, Any]
     connection_type: Any
     message_selection_policy: Any
     transfers: AbstractStore = field(default_factory=InMemoryStore)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import os.path
+
+import pytest
+
+from skeleton_etl.models.gateway import Gateway
+from skeleton_etl.connections.filesystem import (
+    LocalFilesystemConnection,
+    LocalFilesystemConnectionSettings,
+)
+from skeleton_etl.selection_policies.all import SelectionPolicyAll
+
+
+TEST_DIR = Path(os.path.abspath(__file__)).parent.absolute()
+DATA_DIR = TEST_DIR / "data"
+
+
+@pytest.fixture
+def root_path():
+    return DATA_DIR
+
+
+@pytest.fixture
+def good_gateway(root_path):
+    return Gateway(
+        path=str(DATA_DIR),
+        connection_settings=LocalFilesystemConnectionSettings(root_path=root_path),
+        connection_type=LocalFilesystemConnection,
+        message_selection_policy=SelectionPolicyAll,
+    )
+
+
+@pytest.fixture
+def bad_gateway():
+    class IncorrectConnectionSettings:
+        pass
+
+    return Gateway(
+        path=str(DATA_DIR),
+        connection_settings=IncorrectConnectionSettings(),
+        connection_type=LocalFilesystemConnection,
+        message_selection_policy=SelectionPolicyAll,
+    )
+
+
+def test_good_local_collection(good_gateway, root_path):
+    conn = LocalFilesystemConnection()
+    con_path = conn.connect(good_gateway)
+    assert con_path == root_path
+
+
+def test_bad_connection(bad_gateway):
+    conn = LocalFilesystemConnection()
+    with pytest.raises(TypeError):
+        conn.connect(bad_gateway)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -6,7 +6,10 @@ import pytest
 
 from skeleton_etl.models.gateway import Gateway
 from skeleton_etl.models.transfer import Transfer
-from skeleton_etl.connections.filesystem import LocalFilesystemConnection
+from skeleton_etl.connections.filesystem import (
+    LocalFilesystemConnection,
+    LocalFilesystemConnectionSettings,
+)
 from skeleton_etl.selection_policies.all import SelectionPolicyAll
 
 from skeleton_etl.message_types.product_demo import ProductMessage
@@ -27,7 +30,7 @@ def register_product_demo_type():
 def gateway(register_product_demo_type):
     return Gateway(
         path=str(DATA_DIR),
-        address=None,
+        connection_settings=LocalFilesystemConnectionSettings(),
         connection_type=LocalFilesystemConnection,
         message_selection_policy=SelectionPolicyAll,
     )


### PR DESCRIPTION
The connection settings type is defined by the connection and allows validation that sensible parameters are being passed into the connection

Signed-off-by: Michele Costa <michele.costa@unipart.io>

# TODO: 
[X] Add tests